### PR TITLE
Environment variables should be set in ~/.zshenv

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,9 +21,13 @@ then simply copy and paste:
 
 > My Vim insists on using the system Ruby.
 
-You're using zsh on OS X, aren't you? Set your `PATH` in `~/.zshenv`
-instead of `~/.zshrc`. This includes enabling shims in case you are
-using rbenv.
+You're using zsh on OS X, aren't you? You've got multiple options here.
+You can
+
+* Move `/etc/zshenv` to `/etc/zshrc`
+* Set your `PATH` in `~/.zshenv` instead of `~/.zshrc`.
+
+Got another solution? Open up a Pull Request.
 
 ## Self-Promotion
 


### PR DESCRIPTION
Moving /etc/zshenv to /etc/zshrc causes a change in the expected load order of zsh config files.
