### PR TITLE
Add ruby-build hook to pre-calculate g:ruby_version_paths.

### DIFF
--- a/contrib/README.txt
+++ b/contrib/README.txt
@@ -1,0 +1,23 @@
+The bash script in this directory is a hook for ruby-build, the rbenv plugin
+that provides interpreter installation and removal functions.
+
+The script pre-calculates the value of the g:ruby_version_paths variable used
+by vim-ruby and vim-rbenv upon any interpreter installation or removal and
+saves that information in the .vim_ruby_version_paths file in your home
+directory, thus leading to ***MASSIVE*** speedup times at Vim startup.
+
+It can be installed by simply copying it in the following directories:
+
+  ~/.rbenv/rbenv.d/install
+  ~/.rbenv/rbenv.d/uninstall
+
+Then, you need to add the following code at the beginning of your .vimrc:
+
+  " Use precalculated g:ruby_version_paths to speed up load time
+  " (need to do this before file type detection support is loaded)
+  if filereadable(expand("~/.vim_ruby_version_paths"))
+    source $HOME/.vim_ruby_version_paths
+  endif
+
+to make it source the ~/.vim_ruby_version_paths file containing the
+pre-calculated value of g:ruby_version_paths.

--- a/contrib/update_ruby_version_paths.bash
+++ b/contrib/update_ruby_version_paths.bash
@@ -1,0 +1,28 @@
+# Redirect all output to ~/.vim_ruby_versions_paths
+exec > ~/.vim_ruby_version_paths
+
+# Get the names of all the installed Ruby versions
+VERSIONS=`rbenv versions --bare`
+case $VERSIONS in
+    *system*)
+        # VERSIONS already includes "system" - nothing to do
+        ;;
+    *)  # VERSIONS does not include "system" - check if it should
+        if RBENV_VERSION=system rbenv which ruby &>/dev/null
+        then
+            VERSIONS="$VERSIONS system"
+        fi
+        ;;
+esac
+
+echo 'let g:ruby_version_paths = {'
+
+for rv in $VERSIONS
+do
+    echo "  \\ '$rv': "
+    # Print load path for version $rv
+    RBENV_VERSION=$rv ruby -e 'print "  \\   #{$:}"' 2>/dev/null
+    echo ","
+done
+
+echo '  \ }'


### PR DESCRIPTION
This hook script for ruby-build pre-calculates the value of the g:ruby_version_paths variable used by vim-ruby and vim-rbenv upon any interpreter installation or removal, thus leading to massive speedup times at Vim startup.

Further details and installation instructions are provided in the accompanying README.txt file.
